### PR TITLE
GMD latest bug fix

### DIFF
--- a/R/gmd.R
+++ b/R/gmd.R
@@ -59,11 +59,11 @@ dlw_get_gmd <- function(country_code,
   if (is.null(vermast) & is.null(veralt) & latest_version == TRUE) {
     ctl <- ctl[ ,
                 #  for each year, the row(s) with the maximum Vermast.
-                .SD[Vermast == max(Vermast)],
+                .SD[toupper(Vermast) == max(toupper(Vermast))],
                 by = Year
                 ][,
                   #It should return only one row per year (even if there are ties)
-                  .SD[Veralt == max(Veralt, na.rm = TRUE)],
+                  .SD[toupper(Veralt) == max(toupper(Veralt), na.rm = TRUE)],
                   by = Year]
   }
 
@@ -145,7 +145,7 @@ dlw_get_gmd_support <- function(module = c("CPIICP", "CPI"),
   # get latest by default.
 
   if (is.null(vermast)) {
-    ctl <- ctl[Vermast == max(Vermast, na.rm = TRUE)]
+    ctl <- ctl[toupper(Vermast) == max(toupper(Vermast), na.rm = TRUE)]
   } else {
     ctl <- ctl[Vermast == Vermast]
   }


### PR DESCRIPTION
`dlw_get_gmd()` does not get latest version in specific cases where version name changes from upper to lower case. Example:

``` r
library(dlw)

gmd_latest <- dlw_get_gmd("PHL", 2006L, "ALL", latest_version = TRUE) 
#> Pruning cache
#> 
#> ── dlw_get_data Calls ──────────────────────────────────────────────────────────
#> Call 1:
#> dlw_get_data(
#>   country_code = "PHL",
#>   year = 2006L,
#>   server = "GMD",
#>   survey = "FIES",
#>   module = "ALL",
#>   filename = "PHL_2006_FIES_V02_M_V01_A_GMD_ALL.dta",
#>   collection = "GMD"
#> )
#> Creating new version '20250801T104201Z-62889'
#> Writing to pin ''PHL_2006_FIES_V02_M_V01_A_GMD_ALL.qs''

dlw_server_catalog("GMD")[
  Country_code == "PHL" & 
    Survey_year == 2006L & 
    Collection == "GMD" & 
    Module == "ALL"
][
  order(toupper(Vermast), toupper(Veralt))
][
  , .SD, .SDcols = Country_code:Module
]
#> ℹ Returning ServerCatalog_GMD from .dlwevn
#>    Country_code Survey_year Survey_acronym Vermast Veralt Collection Module
#>          <char>      <char>         <char>  <char> <char>     <char> <char>
#> 1:          PHL        2006           FIES     V02    V01        GMD    ALL
#> 2:          PHL        2006           FIES     v02    v05        GMD    ALL
#> 3:          PHL        2006           FIES     v02    v06        GMD    ALL
```

<sup>Created on 2025-08-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The PR adds case conversion for the correct version is identified in these cases.