### PR TITLE
Default to qs2 format (qs is defunct in pins 1.4.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://github.com/worldbank/dlw, https://worldbank.github.io/dlw/
 BugReports: https://github.com/worldbank/dlw/issues
 Depends: 
     R (>= 3.5)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports: 
     cli,
     data.table,
@@ -23,6 +23,7 @@ Imports:
     httr2,
     keyring,
     pins,
+    qs2,
     rlang,
     stats
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dlw
 Type: Package
 Title: R Client for the internal Datalibweb API of the World Bank
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: person("R.Andres", "Castaneda",
                             email = "acastanedaa@worldbank.org",
                             role = c("aut", "cre"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,13 @@ Package: dlw
 Type: Package
 Title: R Client for the internal Datalibweb API of the World Bank
 Version: 0.1.2
-Authors@R: person("R.Andres", "Castaneda",
+Authors@R: c(
+    person("R.Andres", "Castaneda",
                             email = "acastanedaa@worldbank.org",
-                            role = c("aut", "cre"))
+                            role = c("aut", "cre")),
+    person("Ben", "Brunckhorst",
+                            email = "84766772+bbrunckh@users.noreply.github.com",
+                            role = "ctb"))
 Description: More about what it does (maybe more than one line).
     Continuation lines should be indented.
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# dlw 0.1.2
+
 # dlw 0.1.1
 
 * fixes issue in #14

--- a/R/dlw_get_data.R
+++ b/R/dlw_get_data.R
@@ -9,8 +9,8 @@
 #'   in option dlw.local_dir which is set initially as "".
 #' @param local logical: whether or not to save and read data locally. default
 #'   is TRUE if `local_dir` exists.
-#' @param format character: File format to use for pinning data ('parquet'
-#'   [default] or 'qs')
+#' @param format character: File format to use for pinning data ('qs2'
+#'   [default] or 'parquet')
 #' @param local_overwrite logical. Whether to overwrite any saved data. Default
 #'   is FALSE
 #' @param version numeric: Version of the pin to read (for pinning data
@@ -69,7 +69,7 @@ dlw_get_data <- function(country_code,
 #' @inheritParams dlw_get_data
 #' @inheritParams dlw_read
 #' @param filename character: Name of the file to save/read (required)
-#' @param format character: File format to use for pinning data ('qs'
+#' @param format character: File format to use for pinning data ('qs2'
 #'   [default] or 'parquet')
 #' @returns A list with the board and pin_name used
 #' @keywords internal

--- a/R/dlw_get_data.R
+++ b/R/dlw_get_data.R
@@ -89,7 +89,7 @@ dlw_download <- function(country_code,
 
   # prepare the args for request
   dots <- list(...)
-  endpoint <- "FileInformation/GetFileInfo"
+  endpoint <- "FileInformationInternal/GetFileInfo"
   args <- c(list(Country = country_code,
                  method = "POST",
                  Server = server,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,7 @@ op.dlw <- list(
   cli.ignore_unknown_rstudio_theme = TRUE,
   dlw.local_dir = Sys.getenv("DLW_local_dir"),
   dlw.board_type = c("folder", "local"),
-  dlw.format     = c("qs", "parquet"),
+  dlw.format     = c("qs2", "parquet"),
   dlw.download_formats = c("dta") # we could add more later.
 )
 

--- a/man/dlw_download.Rd
+++ b/man/dlw_download.Rd
@@ -24,7 +24,7 @@ dlw_download(
 
 \item{pin_name}{The name of the pin (as returned by dlw_download)}
 
-\item{format}{character: File format to use for pinning data ('qs'
+\item{format}{character: File format to use for pinning data ('qs2'
 [default] or 'parquet')}
 
 \item{server}{character: in case we have more than one server. default is  GMD}

--- a/man/dlw_get_data.Rd
+++ b/man/dlw_get_data.Rd
@@ -30,8 +30,8 @@ in option dlw.local_dir which is set initially as "".}
 \item{local}{logical: whether or not to save and read data locally. default
 is TRUE if `local_dir` exists.}
 
-\item{format}{character: File format to use for pinning data ('parquet'
-[default] or 'qs')}
+\item{format}{character: File format to use for pinning data ('qs2'
+[default] or 'parquet')}
 
 \item{local_overwrite}{logical. Whether to overwrite any saved data. Default
 is FALSE}


### PR DESCRIPTION
## Summary
Switches the default `dlw.format` from `"qs"` to `"qs2"`.

`"qs"` no longer works: as of **pins 1.4.2**, `type = "qs"` is defunct —
`pins::pin_write()` errors and tells the caller to use `"qs2"`. The `qs`
package has been archived on CRAN; `qs2` is its maintained successor. So
every `dlw_get_data()` call using the default format currently fails at
the pin-write step.

## Changes
- `R/zzz.R`: `dlw.format` default `c("qs", "parquet")` → `c("qs2", "parquet")`
  (first element is the `match.arg()` default; `"parquet"` stays valid).
- `DESCRIPTION`: add `qs2` to `Imports`. `pins` only lists `qs2` under
  `Suggests`, so it isn't installed transitively — and it now backs the default.
- `R/dlw_get_data.R` + regenerated `man/*.Rd`: update `@param format` docs.
