### PR TITLE
Fix data downloads: use FileInformationInternal/GetFileInfo endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dlw
 Type: Package
 Title: R Client for the internal Datalibweb API of the World Bank
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: person("R.Andres", "Castaneda",
                             email = "acastanedaa@worldbank.org",
                             role = c("aut", "cre"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,13 @@ Package: dlw
 Type: Package
 Title: R Client for the internal Datalibweb API of the World Bank
 Version: 0.1.2
-Authors@R: person("R.Andres", "Castaneda",
+Authors@R: c(
+    person("R.Andres", "Castaneda",
                             email = "acastanedaa@worldbank.org",
-                            role = c("aut", "cre"))
+                            role = c("aut", "cre")),
+    person("Ben", "Brunckhorst",
+                            email = "84766772+bbrunckh@users.noreply.github.com",
+                            role = "ctb"))
 Description: More about what it does (maybe more than one line).
     Continuation lines should be indented.
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# dlw 0.1.2
+
 # dlw 0.1.1
 
 * fixes issue in #14

--- a/R/dlw_get_data.R
+++ b/R/dlw_get_data.R
@@ -89,7 +89,7 @@ dlw_download <- function(country_code,
 
   # prepare the args for request
   dots <- list(...)
-  endpoint <- "FileInformation/GetFileInfo"
+  endpoint <- "FileInformationInternal/GetFileInfo"
   args <- c(list(Country = country_code,
                  method = "POST",
                  Server = server,


### PR DESCRIPTION
## Problem

All data downloads via `dlw_get_data()` / `dlw_get_gmd()` fail with `Error with the DLW request` — including the package's own documented example `dlw_get_gmd("PRY", 2010, "GPWG")`.

The cause is server-side behavior of the endpoint the package calls: `POST FileInformation/GetFileInfo` returns an unconditional HTTP 500 for **every** request (with a valid token).

## Fix

The Stata `datalibweb` plugin (Dlib2SOL DLL) calls `FileInformationInternal/GetFileInfo` instead, which accepts the same request shape with plain bearer-token auth and works. This PR switches the endpoint (one line).